### PR TITLE
Fix colored True Level suffix duplication

### DIFF
--- a/true_level/scripts/mods/true_level/elements/team_panel.lua
+++ b/true_level/scripts/mods/true_level/elements/team_panel.lua
@@ -22,8 +22,23 @@ local _salvage_enabled = function(game_mode)
 end
 
 local _set_widget_visible = function(widget, visible)
-    if widget and widget.content.visible ~= visible then
+    if not widget then
+        return
+    end
+
+    local changed = false
+
+    if widget.visible ~= visible then
+        widget.visible = visible
+        changed = true
+    end
+
+    if widget.content.visible ~= visible then
         widget.content.visible = visible
+        changed = true
+    end
+
+    if changed then
         widget.dirty = true
     end
 end
@@ -62,14 +77,14 @@ local _restore_vanilla_salvage = function(panel, show_widget)
 end
 
 local _trim_previous_salvage = function(text, previous_text)
-    if not previous_text then
+    if not previous_text or previous_text == "" then
         return text
     end
 
     local suffix = " " .. previous_text
 
-    if string.sub(text, -#suffix) == suffix then
-        return string.sub(text, 1, #text - #suffix)
+    while string.sub(text, -#suffix) == suffix do
+        text = string.sub(text, 1, #text - #suffix)
     end
 
     return text
@@ -154,9 +169,19 @@ local _append_player_salvage = function(panel, player, game_mode, style)
 
     local content = widget.content
     local original_text = content.text or ""
+    local text = _player_salvage_text(style, salvage_amount)
     local current_text = _trim_previous_salvage(original_text, panel.tl_salvage_text)
 
+    if panel.tl_salvage_text ~= text then
+        current_text = _trim_previous_salvage(current_text, text)
+    end
+
     if current_text == "" then
+        if current_text ~= original_text then
+            content.text = current_text
+            widget.dirty = true
+        end
+
         return false
     end
 
@@ -166,18 +191,14 @@ local _append_player_salvage = function(panel, player, game_mode, style)
         container_size[1] = math.max(container_size[1], PLAYER_NAME_WITH_SALVAGE_WIDTH)
     end
 
-    if panel.tl_salvage_base_text == current_text
-        and panel.tl_salvage_amount == salvage_amount
-        and panel.tl_salvage_style == style
-        and original_text ~= current_text
-    then
-        return true
-    end
-
-    local text = _player_salvage_text(style, salvage_amount)
     local new_text = current_text .. " " .. text
 
     if original_text == new_text then
+        panel.tl_salvage_text = text
+        panel.tl_salvage_base_text = current_text
+        panel.tl_salvage_amount = salvage_amount
+        panel.tl_salvage_style = style
+
         return true
     end
 

--- a/true_level/scripts/mods/true_level/true_level.lua
+++ b/true_level/scripts/mods/true_level/true_level.lua
@@ -197,6 +197,15 @@ local _concat_levels = function(ref)
     return result
 end
 
+local _trim_added_levels = function(text)
+    -- Color markup can make the appended level suffix start with "{#color...}"
+    -- instead of a digit, so strip both plain and colored variants.
+    text = text:gsub("%s+%-%s+%d.+", "")
+    text = text:gsub("%s+%-%s+{#.-}%d.+", "")
+
+    return text
+end
+
 mod.replace_level = function(text, true_levels, reference, need_adding)
     _init_levels()
 
@@ -224,7 +233,7 @@ mod.replace_level = function(text, true_levels, reference, need_adding)
     end
 
     if need_adding then
-        text = text:gsub("%s+%-%s+%d.+", "")
+        text = _trim_added_levels(text)
     end
 
     if display_style ~= "none" then


### PR DESCRIPTION
ColorSelection can reset team panel modification flags after wrapping player name text in rich color tags. When Who Are You is disabled, True Level then reprocesses its own previously appended level suffix.

The old cleanup only stripped suffixes shaped like " - 310 ...", so colored suffixes such as " - {#color(...)}310..." were treated as part of the base name and another level block was appended. This could repeat until the HUD was filled with duplicated level or salvage text.

Add cleanup for colored appended level suffixes, harden salvage suffix trimming against repeated stale tails, and hide the vanilla expedition currency widget using both widget-level and content-level visibility.